### PR TITLE
Read line item params correctly

### DIFF
--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -24,9 +24,11 @@ module Spree
         update_success = super(params)
 
         if update_success && params[:line_items_attributes]
-          line_item = Spree::LineItem.find_by(id: params[:line_items_attributes][:id])
-          new_quantity = params[:line_items_attributes][:quantity].to_i
-          update_gift_cards(line_item, new_quantity)
+          params[:line_items_attributes].values.each do |line_item_attributes|
+            line_item = Spree::LineItem.find_by(id: line_item_attributes[:id])
+            new_quantity = line_item_attributes[:quantity].to_i
+            update_gift_cards(line_item, new_quantity)
+          end
         end
 
         update_success
@@ -81,4 +83,3 @@ module Spree
     end
   end
 end
-

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -229,7 +229,9 @@ describe Spree::OrderContents do
 
       let(:update_params) do
         {
-          line_items_attributes: { id: @line_item.id, quantity: quantity, options: {}}
+          line_items_attributes: {
+            '0' => { id: @line_item.id, quantity: quantity, options: {}}
+          }
         }
       end
 


### PR DESCRIPTION
The specs and code for reading the updated line item params is not correct. The end result is that on update the gift cards are not modified correctly.