### PR TITLE
Allow gift card to be sent to purchaser

### DIFF
--- a/app/mailers/spree/gift_card_mailer.rb
+++ b/app/mailers/spree/gift_card_mailer.rb
@@ -2,7 +2,8 @@ class Spree::GiftCardMailer < Spree::BaseMailer
   def gift_card_email(gift_card)
     @gift_card = gift_card.respond_to?(:id) ? gift_card : Spree::VirtualGiftCard.find(gift_card)
     @order = @gift_card.line_item.order
-    send_to_address = @gift_card.recipient_email.presence || @order.email
+    send_to_address = @order.email
+    send_to_address = @gift_card.recipient_email unless @gift_card.send_to_purchaser?
     subject = "#{Spree::Store.default.name} #{Spree.t('gift_card_mailer.gift_card_email.subject')}"
     mail(to: send_to_address, from: from_address(Spree::Store.default), subject: subject)
   end

--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -47,7 +47,8 @@ module Spree
               recipient_email: gift_card_details["recipient_email"],
               purchaser_name: gift_card_details["purchaser_name"],
               gift_message: gift_card_details["gift_message"],
-              send_email_at: format_date(gift_card_details["send_email_at"])
+              send_email_at: format_date(gift_card_details["send_email_at"]),
+              send_to_purchaser: gift_card_details["send_to_purchaser"],
             )
           end
         end

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -70,6 +70,7 @@ class Spree::VirtualGiftCard < Spree::Base
       recipient_name: recipient_name,
       purchaser_name: purchaser_name,
       gift_message: gift_message,
+      send_to_purchaser: send_to_purchaser ? '1' : '0',
       send_email_at: send_email_at,
       formatted_send_email_at: formatted_send_email_at
     }

--- a/db/migrate/20171208105000_allow_receiver_to_get_gift_card.rb
+++ b/db/migrate/20171208105000_allow_receiver_to_get_gift_card.rb
@@ -1,0 +1,5 @@
+class AllowReceiverToGetGiftCard < ActiveRecord::Migration
+  def change
+    add_column :spree_virtual_gift_cards, :send_to_purchaser, :boolean, default: false, null: false
+  end
+end

--- a/spec/mailers/spree/gift_card_mailer_spec.rb
+++ b/spec/mailers/spree/gift_card_mailer_spec.rb
@@ -16,5 +16,16 @@ describe Spree::GiftCardMailer, type: :mailer do
         expect(subject.to).to contain_exactly('gift_card_tester@example.com')
       end
     end
+
+    context 'send to purchaser' do
+      before do
+        gift_card.update_attributes! send_to_purchaser: true
+        gift_card.line_item.order.update_attributes!(email: "gift_card_tester@example.com")
+      end
+
+      it 'will send to email on order' do
+        expect(subject.to).to contain_exactly 'gift_card_tester@example.com'
+      end
+    end
   end
 end

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -18,6 +18,7 @@ describe Spree::OrderContents do
         "purchaser_name" => purchaser_name,
         "gift_message" => gift_message,
         "send_email_at" => send_email_at,
+        "send_to_purchaser" => '1',
       }
     }
   end
@@ -46,6 +47,7 @@ describe Spree::OrderContents do
           expect(gift_card.purchaser_name).to eq(purchaser_name)
           expect(gift_card.gift_message).to eq(gift_message)
           expect(gift_card.send_email_at).to eq(send_email_at.to_date)
+          expect(gift_card.send_to_purchaser).to eq true
         end
 
         context "#format_date" do

--- a/spec/models/spree/virtual_gift_card_spec.rb
+++ b/spec/models/spree/virtual_gift_card_spec.rb
@@ -327,4 +327,18 @@ describe Spree::VirtualGiftCard do
       expect { subject }.to change { gift_card.sent_at }
     end
   end
+
+  describe 'details' do
+    let(:data) { subject.details }
+
+    it 'will return a string 1 if configured to send to purchaser' do
+      subject.send_to_purchaser = true
+      expect( data[:send_to_purchaser] ).to eq '1'
+    end
+
+    it 'will return a string 0 if configured to send to recipient' do
+      subject.send_to_purchaser = false
+      expect( data[:send_to_purchaser] ).to eq '0'
+    end
+  end
 end


### PR DESCRIPTION
Since this gem has no frontend and a minimal e-mail the only change is tracking this info and the tweak in direction in the mailer. It would be up to the app to act on this info.